### PR TITLE
Add AJAX functionality for refreshing company deals

### DIFF
--- a/Modules/CRMCore/app/Http/Controllers/CompanyController.php
+++ b/Modules/CRMCore/app/Http/Controllers/CompanyController.php
@@ -305,6 +305,28 @@ class CompanyController extends Controller
     }
 
     /**
+     * Get updated company data for AJAX refresh after deal creation.
+     */
+    public function getCompanyDealsAjax(Company $company)
+    {
+        try {
+            $company->load([
+                'deals' => function ($query) {
+                    $query->with(['dealStage:id,name,color', 'assignedToUser:id,first_name,last_name', 'contact:id,first_name,last_name'])
+                        ->orderBy('expected_close_date', 'desc');
+                },
+            ]);
+
+            return Success::response([
+                'deals' => $company->deals,
+            ]);
+        } catch (Exception $e) {
+            Log::error("Company Get Deals Ajax Error for ID {$company->id}: " . $e->getMessage());
+            return Error::response(__('Failed to fetch updated deals data'));
+        }
+    }
+
+    /**
      * Search for companies for Select2 AJAX.
      */
     public function selectSearch(Request $request)

--- a/Modules/CRMCore/resources/assets/js/companies/show.js
+++ b/Modules/CRMCore/resources/assets/js/companies/show.js
@@ -320,6 +320,31 @@ $(function () {
     }
   });
 
+  // Handle edit deal button clicks (both from initial load and dynamically added)
+  $(document).on('click', '.edit-deal-from-related', function() {
+    const dealId = $(this).data('deal-id');
+    if (!dealId || !dealOffcanvas) return;
+    
+    // Fetch deal details via AJAX
+    const url = pageData.urls.getDealTemplate.replace('__DEAL_ID__', dealId);
+    $.ajax({
+      url: url,
+      type: 'GET',
+      success: function(response) {
+        // Handle both direct response and wrapped response formats
+        const dealData = response.data || response;
+        if (dealData && dealData.id) {
+          populateDealOffcanvasForEdit(dealData);
+        } else {
+          Swal.fire(pageData.labels.error, pageData.labels.couldNotFetch || 'Could not fetch deal details.', 'error');
+        }
+      },
+      error: function() {
+        Swal.fire(pageData.labels.error, pageData.labels.unexpectedError || 'An unexpected error occurred.', 'error');
+      }
+    });
+  });
+
   if (dealForm) {
     $(dealForm).on('submit', function(e) {
       e.preventDefault();

--- a/Modules/CRMCore/resources/views/companies/show.blade.php
+++ b/Modules/CRMCore/resources/views/companies/show.blade.php
@@ -71,6 +71,7 @@ use Illuminate\Support\Str;
       $contactSearchUrl = route('contacts.selectSearch');
       $leadSearchUrl = route('leads.selectSearch');
       $dealSearchForTaskUrl = route('deals.selectSearch'); // For task "related to deal"
+      $companyDealsAjaxUrl = route('companies.dealsAjax', ['company' => $companyIdForRoute]);
 
       // Data for static dropdowns
       $taskStatusesData = Modules\CRMCore\App\Models\TaskStatus::orderBy('position')->pluck('name', 'id')->all();
@@ -91,7 +92,7 @@ use Illuminate\Support\Str;
               })
           ]];
       })->all();
-      $initialPipelineIdData = (Modules\CRMCore\App\Models\DealPipeline::where('is_default', true)->first() ?? \App\Models\DealPipeline::orderBy('position')->first())->id ?? null;
+      $initialPipelineIdData = (Modules\CRMCore\App\Models\DealPipeline::where('is_default', true)->first() ?? Modules\CRMCore\App\Models\DealPipeline::orderBy('position')->first())->id ?? null;
 
     @endphp
 
@@ -131,7 +132,8 @@ use Illuminate\Support\Str;
         companySearch: @json($companySearchUrl),
         contactSearch: @json($contactSearchUrl),
         leadSearch: @json($leadSearchUrl),
-        dealSearch: @json($dealSearchForTaskUrl) // Specifically for task's "related to deal"
+        dealSearch: @json($dealSearchForTaskUrl), // Specifically for task's "related to deal"
+        companyDealsAjax: @json($companyDealsAjaxUrl) // AJAX endpoint to refresh deals after creation
       },
       taskStatuses: @json($taskStatusesData),
       taskPriorities: @json($taskPrioritiesData),

--- a/Modules/CRMCore/routes/web.php
+++ b/Modules/CRMCore/routes/web.php
@@ -46,6 +46,7 @@ Route::middleware(['auth'])->group(function () {
         Route::post('/', [CompanyController::class, 'store'])->name('store');
 
         Route::get('/{company}', [CompanyController::class, 'show'])->name('show'); // Route model binding
+        Route::get('/{company}/deals-ajax', [CompanyController::class, 'getCompanyDealsAjax'])->name('dealsAjax'); // AJAX endpoint for deals refresh
         Route::get('/{company}/edit', [CompanyController::class, 'edit'])->name('edit'); // Route model binding
         Route::put('/{company}', [CompanyController::class, 'update'])->name('update'); // Route model binding
 

--- a/resources/views/_partials/_modals/core/license.blade.php
+++ b/resources/views/_partials/_modals/core/license.blade.php
@@ -33,7 +33,6 @@
             <div class="d-flex justify-content-center">
               <a href="javascript:" class="btn btn-primary me-1_5">
                 Activate with
-                <img class="ms-2" src="{{asset('assets/img/envato.svg')}}" alt="Activate with envato" width="100">
               </a>
             </div>
 


### PR DESCRIPTION
Introduce AJAX endpoints to refresh company deals after creation and to edit deals from related items, enhancing user experience by allowing dynamic updates without full page reloads.