### PR TITLE
Fix category icon and color display issues

### DIFF
--- a/Modules/AccountingCore/resources/assets/js/categories.js
+++ b/Modules/AccountingCore/resources/assets/js/categories.js
@@ -44,6 +44,7 @@ function initializeDataTable() {
             { data: 'type_badge', name: 'type' },
             { data: 'parent_name', name: 'parent_id' },
             { data: 'icon_display', name: 'icon' },
+            { data: 'color_display', name: 'color' },
             { data: 'transaction_count', name: 'transaction_count' },
             { data: 'status', name: 'is_active' },
             { data: 'actions', name: 'actions', orderable: false, searchable: false }

--- a/Modules/AccountingCore/resources/views/categories/index.blade.php
+++ b/Modules/AccountingCore/resources/views/categories/index.blade.php
@@ -41,6 +41,7 @@
             <th>{{ __('Type') }}</th>
             <th>{{ __('Parent Category') }}</th>
             <th>{{ __('Icon') }}</th>
+            <th>{{ __('Color') }}</th>
             <th>{{ __('Transactions') }}</th>
             <th>{{ __('Status') }}</th>
             <th>{{ __('Actions') }}</th>


### PR DESCRIPTION
## Summary
- Fixed category icon and color display issues in AccountingCore module
- Added missing Color column to categories table HTML and DataTable configuration
- Icons and colors now display properly in the categories listing

## Changes Made
- Added `<th>{{ __('Color') }}</th>` to categories table header in `index.blade.php`
- Added `{ data: 'color_display', name: 'color' }` to JavaScript DataTable columns in `categories.js`

## Test Plan
- Verified backend already generates icon_display and color_display data correctly
- Tested live application - icons and colors now display in categories table
- No database changes required - backend was already working

Fixes #36

🤖 Generated with [Claude Code](https://claude.ai/code)